### PR TITLE
Warnings cleanup for Apple's Clang 15.0 compiler

### DIFF
--- a/cline.c
+++ b/cline.c
@@ -37,7 +37,7 @@
 #define CHAR_FOLDER_CHANGE_T2	3
 
 // -9 and -V not shown
-void PrintUsage()
+void PrintUsage(void)
 {
 	logmsg("  usage: mdfourier -P profile.mdf -r reference.wav -c compare.wav\n");
 	logmsg("   FFT and Analysis options:\n");

--- a/flac.c
+++ b/flac.c
@@ -58,7 +58,7 @@ static FLAC__StreamDecoderWriteStatus write_callback(const FLAC__StreamDecoder *
 static void metadata_callback(const FLAC__StreamDecoder *decoder, const FLAC__StreamMetadata *metadata, void *client_data);
 static void error_callback(const FLAC__StreamDecoder *decoder, FLAC__StreamDecoderErrorStatus status, void *client_data);
 
-char* getflacErrorStr()
+char* getflacErrorStr(void)
 {
 	if(flacInternalErrorStr[0] != 0)
 		return(flacInternalErrorStr);
@@ -66,7 +66,7 @@ char* getflacErrorStr()
 		return NULL;
 }
 
-int flacErrorReported()
+int flacErrorReported(void)
 {
 	return(flacInternalMDFErrors);
 }

--- a/log.c
+++ b/log.c
@@ -44,11 +44,11 @@ int do_log = 0;
 char log_file[T_BUFFER_SIZE];
 FILE *logfile = NULL;
 
-void EnableLog() { do_log = CONSOLE_ENABLED; }
-void DisableLog() { do_log = 0; }
-int IsLogEnabled() { return do_log; }
+void EnableLog(void) { do_log = CONSOLE_ENABLED; }
+void DisableLog(void) { do_log = 0; }
+int IsLogEnabled(void) { return do_log; }
 
-void initLog()
+void initLog(void)
 {
 	do_log = 0;
 	logfile = NULL;
@@ -135,7 +135,7 @@ int setLogName(char *name)
 	return 1;
 }
 
-void endLog()
+void endLog(void)
 {
 	if(logfile)
 	{

--- a/mdwave.c
+++ b/mdwave.c
@@ -1086,7 +1086,7 @@ int commandline_wave(int argc , char *argv[], parameters *config)
 	return 1;
 }
 
-void PrintUsage_wave()
+void PrintUsage_wave(void)
 {
 	logmsg("  usage: mdwave -P profile.mdf -r audio.wav\n");
 	logmsg("   FFT and Analysis options:\n");


### PR DESCRIPTION
Warnings cleanup for Apple's Clang 15.0 compiler, mostly passing "void" to functions which do not need any variables to comply with "-Wstrict-prototypes".