### PR TITLE
Fix an error for detecting Apple Silicon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ ifeq ($(UNAME),Darwin)
 all:mac
 endif
 
-ifeq ($(UNAME),DarwinARM64)
+ifeq ($(UNAME),DarwinARM)
 all:macarm
 endif
 


### PR DESCRIPTION
There was a mistake in the Makefile which made MDFourier unable to compile on Apple Silicon Macs.